### PR TITLE
Add Component Constructors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 .idea
 
+bin/
 build/
 out/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,31 @@ Semver("2.1.0-beta.1") > Semver("2.1.0-beta") // true
 Semver("2.1.0-rc.11") < Semver("2.1.0") // true
 ```
 
+### Components
+
+You can also create `Semver` objects by passing in individual components of the version number:
+
+```kotlin
+val semver = Semver(1, 5, 12)
+println(semver) // 1.5.12
+
+println(semver.major) // 1
+println(semver.minor) // 5
+println(semver.patch) // 12
+
+val semverPrerelease = Semver(1, 5, 13, "beta.1")
+println(semverPrerelease) // 1.5.13-beta.1
+println(semverPrerelease.preReleaseVersion) // beta.1
+
+val semverString = Semver("1.5.14-alpha.10")
+println(semverString) // 1.5.14-alpha.10
+
+println(semverString.major) // 1
+println(semverString.minor) // 5
+println(semverString.patch) // 14
+println(semverString.preReleaseVersion) // alpha.10
+```
+
 ### Formatting
 
 This library is also capable of performing some light formatting on the given input to conform it to the semver convention.

--- a/src/main/kotlin/com/oliverspryn/library/Semver.kt
+++ b/src/main/kotlin/com/oliverspryn/library/Semver.kt
@@ -4,21 +4,97 @@ import com.oliverspryn.library.models.PreReleaseVersion
 import com.oliverspryn.library.models.Version
 
 /**
- * A general-purpose processor for comparing version numbers that
- * adhere to the <a href="https://semver.org">Semantic Versioning 2.0.0 standard</a>.
+ * A general-purpose processor for comparing version numbers and
+ * pre-release versions that adhere to the
+ * [Semantic Versioning 2.0.0 standard](https://semver.org).
  *
- * @param version The version string to compare
- * @constructor Create a fully-processed and understood representation of Semver to compare
- * @throws IllegalArgumentException Whenever the version string does not adhere to Semver standards
+ * Here are a few examples of versions the library can understand:
+ *
+ *   - 0.0.1
+ *   - 1.0.0
+ *   - 2.1.136
+ *   - 2.0.0-alpha
+ *   - 2.0.0-alpha.1
+ *   - 2.0.0-beta.12
+ *   - 2.0.0-rc.3
+ *
+ * Here are a few less common applications of the standard which are not supported by the library:
+ *
+ *   - 1.0.0-0.3.7
+ *   - 1.0.0-x.7.z.92
+ *   - 1.0.0-alpha.beta
  */
-class Semver(version: String) {
+class Semver {
 
-    private val parsedVersion = Version.parse(version)
+    private val parsedVersion: Version
     private val parsedPreReleaseVersion: PreReleaseVersion
 
-    init {
-        parsedPreReleaseVersion = PreReleaseVersion.parse(version, parsedVersion)
+    /**
+     * Constructs a [Semver] object from a version string.
+     *
+     * @param versionString The version string.
+     * @constructor Create a fully-processed and understood representation of Semver.
+     * @throws IllegalArgumentException Whenever the version string does not adhere to Semver standards.
+     */
+    constructor(versionString: String) {
+        parsedVersion = Version.parse(versionString)
+        parsedPreReleaseVersion = PreReleaseVersion.parse(versionString, parsedVersion)
     }
+
+    /**
+     * Constructs a [Semver] object from the [major], [minor], and
+     * [patch] parts of a version.
+     *
+     * @param major The major version number.
+     * @param minor The minor version number.
+     * @param patch The patch version number.
+     * @constructor Create a fully-processed and understood representation of Semver.
+     */
+    constructor(major: Int = 0, minor: Int = 0, patch: Int = 0) {
+        parsedVersion = Version(major, minor, patch)
+        parsedPreReleaseVersion = PreReleaseVersion.parse(parsedVersion.toString(), parsedVersion)
+    }
+
+    /**
+     * Constructs a [Semver] object from the [major], [minor], [patch],
+     * [preReleaseVersion] string parts of a version.
+     *
+     * @param major The major version number.
+     * @param minor The minor version number.
+     * @param patch The patch version number.
+     * @param preReleaseVersion The pre-release version string, such as `alpha`, `beta`, `rc`, or `release`.
+     * @constructor Create a fully-processed and understood representation of [Semver].
+     */
+    constructor(major: Int = 0, minor: Int = 0, patch: Int = 0, preReleaseVersion: String = "release") {
+        parsedVersion = Version(major, minor, patch)
+        val combinedVersion = "$parsedVersion-$preReleaseVersion"
+        parsedPreReleaseVersion = PreReleaseVersion.parse(combinedVersion, parsedVersion)
+    }
+
+    /**
+     * The major version number.
+     */
+    val major: Int
+        get() = parsedVersion.major
+
+    /**
+     * The minor version number.
+     */
+    val minor: Int
+        get() = parsedVersion.minor
+
+    /**
+     * The patch version number.
+     */
+    val patch: Int
+        get() = parsedVersion.patch
+
+    /**
+     * The pre-release version string, such as `alpha`, `beta`, `rc`,
+     * or `release`.
+     */
+    val preReleaseVersion: String
+        get() = parsedPreReleaseVersion.toString()
 
     // region Overloaded Operators
 
@@ -26,7 +102,7 @@ class Semver(version: String) {
      * Overloaded comparison operator to determine if two version strings
      * are equal or if one is greater than another.
      *
-     * @param semver Another Semver object to do a comparison against
+     * @param semver Another [Semver] object to do a comparison against
      * @return 0 when equal, 1 when this object is greater, or -1 when the other object is greater
      */
     operator fun compareTo(semver: Semver): Int {
@@ -40,11 +116,11 @@ class Semver(version: String) {
     }
 
     /**
-     * Accepts comparison against both Semver object and strings. This
-     * class will attempt to cast String objects to Semver objects and
+     * Accepts comparison against both [Semver] object and strings. This
+     * class will attempt to cast [String] objects to [Semver] objects and
      * do comparison from there.
      *
-     * @param other A String or Semver object to compare against
+     * @param other A [String] or [Semver] object to compare against
      * @return Whether the two version stamps are the same
      */
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/oliverspryn/library/main.kt
+++ b/src/main/kotlin/com/oliverspryn/library/main.kt
@@ -60,6 +60,8 @@ fun main() {
     println(Semver("2.01.000100"))
     println(Semver("1.0.0-alpha.0"))
     println(Semver("1.0.00-ALphA.1"))
+    println(Semver(1, 0, 0))
+    println(Semver(3, 1, 4, "rc.1"))
 
     try {
         Semver("Something else")


### PR DESCRIPTION
It would be nice to be able to build a `Semver` object by its component parts and then be able to pull each component off with an accessor, like this:

```kotlin
val semver = Semver(1, 10, 0, "beta")
println(semver.toString()) // 1.10.0-beta

semver.major // 1
semver.minor // 10
// etc.
```