### PR TITLE
Remove Gradle Cache from the Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: gradle
 
       - name: Build the Library
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: gradle
 
       - name: Write Out Secrets to Gradle
         run: |


### PR DESCRIPTION
As a result of the error message encountered in https://github.com/oliverspryn/semver/actions/runs/5513304359/jobs/10051260054#step:5:75 stating:

```
Gradle User Home already exists: will not restore from cache.
```

The caching from each build script that is used while setting up the JDK should be removed.